### PR TITLE
willsofwords-17 Need ability to remove single puzzle input from wordlist

### DIFF
--- a/frontend/src/components/WordlistCategory.vue
+++ b/frontend/src/components/WordlistCategory.vue
@@ -4,8 +4,11 @@ import TextBlock from '@/components/TextBlock.vue'
 import DividerLine from '@/components/DividerLine.vue'
 import type { Category } from '@/views/WordlistView.vue'
 import { ref } from 'vue'
+import ButtonBox from '@/components/ButtonBox.vue'
 
+const {adding = false} = defineProps<{ adding?: boolean }>()
 const category = defineModel<Category>({ required: false, default: null })
+defineEmits(['remove'])
 const word_to_add = ref('')
 
 const addWord = () => {
@@ -22,6 +25,9 @@ const addWord = () => {
 
 <template>
   <div class="category">
+    <div class="actions">
+    <ButtonBox v-if="!adding" colour="red" text="Remove Category" icon="delete" @pressed="$emit('remove')" />
+    </div>
     <InputBlock type="text" v-model="category.category">Title:&nbsp;</InputBlock>
     <div class="input_list">
       <InputBlock type="textarea" v-model="category.short_fact">Short Form Fact:&nbsp;</InputBlock>
@@ -67,5 +73,9 @@ const addWord = () => {
 }
 .wordlist {
   display: flex;
+}
+.actions {
+  display: flex;
+  justify-content: flex-end;
 }
 </style>

--- a/frontend/src/views/WordlistView.vue
+++ b/frontend/src/views/WordlistView.vue
@@ -188,10 +188,10 @@ watch(
     <DividerLine />
     <HeadingBlock :level="2">Categories</HeadingBlock>
     <template v-for="(category, index) in wordlist.category_list" :key="index">
-      <WordlistCategory v-model="wordlist.category_list[index]" />
+      <WordlistCategory v-model="wordlist.category_list[index]" @remove="wordlist.category_list.splice(index, 1)"/>
     </template>
     <HeadingBlock :level="2">Add New Category</HeadingBlock>
-    <WordlistCategory v-model="new_category" />
+    <WordlistCategory v-model="new_category" :adding="true"/>
     <ButtonBox colour="green" text="Add Another" icon="add" @pressed="add_category" />
   </div>
 </template>


### PR DESCRIPTION
# Title - Remove puzzle input (category) from wordlist 

## References

Issue #17

## Description

adding the requested feature of being able to remove puzzle inputs from wordlist.  This will shorten wordlists for testing and allow users to ditch problematic puzzles all together.

## Further work

None expected

## Change Log

feature: remove puzzle fom wordlist
