### PR TITLE
Add Puzzle title font size setting

### DIFF
--- a/backend/defaults/project_settings.json.dist
+++ b/backend/defaults/project_settings.json.dist
@@ -7,6 +7,7 @@
   "outer_margin_inches": 0.25,
   "inner_margin_inches": 0.75,
   "title_box_height_inches": 1.0,
+  "title_font_size_inches": 0.3,
   "wordlist_box_height_inches": 2.0,
   "wordlist_font_size_inches": 0.14,
   "wordlist_line_spacing_inches": 0.02,

--- a/backend/models/project_config.py
+++ b/backend/models/project_config.py
@@ -13,6 +13,7 @@ class ProjectConfig(BaseModel):
     outer_margin_inches: float = Field(..., description="Outer margin in inches")
     inner_margin_inches: float = Field(..., description="Inner margin in inches")
     title_box_height_inches: float = Field(..., description="Title box height in inches")
+    title_font_size_inches: float = Field(..., description="Title font size in inches")
     wordlist_box_height_inches: float = Field(..., description="Wordlist box height in inches")
     wordlist_font_size_inches: float = Field(..., description="Wordlist font size in inches")
     wordlist_line_spacing_inches: float = Field(..., description="Wordlist line spacing in inches")
@@ -74,7 +75,7 @@ class ProjectConfig(BaseModel):
 
     @property
     def title_font_size_pixels(self) -> int:
-        return int(self.title_box_height_pixels * 0.3)
+        return int(self.title_font_size_inches * self.dpi)
 
     @property
     def wordlist_box_height_pixels(self) -> int:


### PR DESCRIPTION
## References

Issue #15 

## Description

Introduced `title_font_size_inches` to `project_settings.json`.  Adjusted the `title_font_size_pixels` property to use the new field for DPI-based calculations. 

Previously this was using a value inferred from the title box height.  The purpose of adding this setting is to allow change to the title font size independent of the title box height.

## Further work

Issue #14  - this change helps with making the title font variable when the title text is too large.

## Change Log

feat: add `title_font_size_inches` to project configuration and update pixel calculation logic
