### PR TITLE
Remove Solutions title page

### DIFF
--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -5,7 +5,6 @@ from .enums import (  # noqa: F401
     LayoutEnum,
     PageTypeEnum,
     SizeEnum,
-    TitlePageEnum,
 )
 from .grid_size import GridSize  # noqa: F401
 from .profanity import ProfanityList  # noqa: F401

--- a/backend/models/enums.py
+++ b/backend/models/enums.py
@@ -19,11 +19,6 @@ class BoardImageEnum(StrEnum):
     SOLUTION = "SOLUTION"
 
 
-class TitlePageEnum(StrEnum):
-    PUZZLE = "PUZZLE"
-    SOLUTION = "SOLUTION"
-
-
 class LayoutEnum(StrEnum):
     SINGLE = "SINGLE"
     DOUBLE = "DOUBLE"

--- a/backend/pages/contents.py
+++ b/backend/pages/contents.py
@@ -7,7 +7,6 @@ from backend.models import (
     LayoutEnum,
     ProjectConfig,
     Puzzle,
-    TitlePageEnum,
 )
 from backend.utils import Logger
 
@@ -52,20 +51,12 @@ class Contents(PrintParams, ABC):
 
 
 class ContentsFront(Contents):
-    def __init__(
-        self, project_config: ProjectConfig, front_type: TitlePageEnum = TitlePageEnum.PUZZLE, print_debug: bool = False
-    ) -> None:
+    def __init__(self, project_config: ProjectConfig, print_debug: bool = False) -> None:
         super().__init__(project_config=project_config, print_debug=print_debug)
-        self.front_type: TitlePageEnum = front_type
 
     def get_content_image(self) -> Image.Image:
-        Logger.get_logger().debug(f"Generating {self.__class__} image for {self.front_type}")
-        if self.front_type == TitlePageEnum.PUZZLE:
-            words = "A Glorious Front Page Goes Here"
-        elif self.front_type == TitlePageEnum.SOLUTION:
-            words = "The Solutions you seek are here"
-        else:
-            raise ValueError("Unknown Board Image Type")
+        Logger.get_logger().debug(f"Generating {self.__class__} image")
+        words = "A Glorious Front Page Goes Here"
         text: ImageText.Text = ImageText.Text(
             text=words,
             font=self.fonts["TITLE_FONT"],

--- a/backend/pages/pages.py
+++ b/backend/pages/pages.py
@@ -7,7 +7,6 @@ from backend.models import (
     PageTypeEnum,
     ProjectConfig,
     PuzzleData,
-    TitlePageEnum,
 )
 from backend.utils import Logger, clear_marker_file, set_marker_file
 
@@ -106,10 +105,9 @@ class Pages(PrintParams):
             raise ValueError("No puzzles in to make in to pages")
         self._add_front_page()
         self._add_puzzle_pages()
-        if len(self.puzzle_pages) % 2 == 1:
+        if len(self.puzzle_pages) % 2 == 0:
             self._add_blank_page()
         set_marker_file(self.filename, int(len(self.puzzle_pages) / self.word_search_data.page_count * 100))
-        self._add_front_page(TitlePageEnum.SOLUTION)
         self._add_solution_pages()
         if len(self.puzzle_pages) % 2 == 1:
             self._add_blank_page()
@@ -170,12 +168,10 @@ class Pages(PrintParams):
             Logger.get_logger().debug(f"Added puzzle page for {puzzle.display_title}")
             set_marker_file(self.filename, int(len(self.puzzle_pages) / self.word_search_data.page_count * 100))
 
-    def _add_front_page(self, front_page_type: TitlePageEnum = TitlePageEnum.PUZZLE):
+    def _add_front_page(self):
         self.puzzle_pages.append(
             Page(
-                content=ContentsFront(
-                    front_type=front_page_type, project_config=self.config, print_debug=self.print_debug
-                ).get_content_image(),
+                content=ContentsFront(project_config=self.config, print_debug=self.print_debug).get_content_image(),
                 page_number=len(self.puzzle_pages) + 1,
                 project_config=self.config,
                 print_debug=self.print_debug,


### PR DESCRIPTION
## References

issue #20 

## Description

The client no longer wanted a solutions title page. this will in stead be replaced with the banner created for issue #21. The logic for blank pages at the end of the puzzles section.  The first page of the solutions should be VERSO and so if there are an even number of puzzles pages then a blank page RECTO is required to ensure solutions appear in the right place.

## Further work

issue #21 - this issue is related and required in same release

## Change Log

chore: remove unused TitlePageEnum and refactor related logic
