### PR TITLE
remove main branch specification in Docker build workflow

### DIFF
--- a/.github/workflows/docker_build_push.yaml
+++ b/.github/workflows/docker_build_push.yaml
@@ -22,7 +22,6 @@ jobs:
         with:
           images: gordywills/wordsworth
           tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}


### PR DESCRIPTION
## Description

changing GitHub action to stop every merge updating the latest docker hub image for client stability

## Change Log

chore: remove unused branch specification in Docker build workflow
